### PR TITLE
Use a public route to get thredds service name

### DIFF
--- a/pavics_datacatalog/magpie_utils.py
+++ b/pavics_datacatalog/magpie_utils.py
@@ -10,7 +10,7 @@ class MagpieService:
         session = requests.Session()
         if token:
             session.cookies.set('auth_tkt', token)
-        response = session.get(magpie_url + '/services')
+        response = session.get(magpie_url + '/users/current/services')
         if response.status_code != 200:
             raise response.raise_for_status()
 


### PR DESCRIPTION
Magpie is now protected and only some routes are public. This fix allow the catalog to query a public route to get the thredds service on the latest version of magpie.