### PR TITLE
add requirements.txt for other environment easier install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.eggs
 *.egg-info/
 pavics_datacatalog/tests/configtests.cfg
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.egg-info/
 pavics_datacatalog/tests/configtests.cfg
+.idea/

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ As a docker container running the wps:
 
     docker build -t pavics-datacatalog .
 
-The pywps config file (pywps.cfg) is available. However, the outputurl
-and outputpath values should not be modified as they are currently
+The pywps config file (pywps.cfg) is available. However, the `outputurl`
+and `outputpath` values should not be modified as they are currently
 dynamically set in other places.
 
 Configure as above and run the local build:
@@ -41,11 +41,11 @@ A local solr database can be used:
 
 Solr will be located at http://localhost:8983/solr
 
-New processes must be added to the pavics_datacatalog/wps_processes/__init__.py
+New processes must be added to the `pavics_datacatalog/wps_processes/__init__.py`
 file.
 
-Tests configuration is done in the configtests.cfg file in the tests directory.
-Tests can be run locally in the tests directory with python test_{something}.py
+Tests configuration is done in the `configtests.cfg` file in the tests directory.
+Tests can be run locally in the tests directory with `python test_{something}.py`
 if the dependencies are all installed locally as well. Otherwise, install
 as a package and run:
 

--- a/pavics_datacatalog/wps_processes/wps_pavicrawler.py
+++ b/pavics_datacatalog/wps_processes/wps_pavicrawler.py
@@ -3,9 +3,13 @@ import time
 import traceback
 import json
 import requests
-from urlparse import urlparse
 from pywps import Process, get_format, configuration
 from pywps import LiteralInput, ComplexOutput
+
+# make urllib parse module Python 2/3 compatible
+from future.standard_library import install_aliases
+install_aliases()
+from urllib.parse import urlparse
 
 from pavics import catalog
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 setuptools
 pywps
 requests
-urlparse
+urllib
+future
 threddsclient
 pavics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 setuptools
 pywps
 requests
+urlparse
+threddsclient
 pavics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 setuptools
 pywps
 requests
-urllib
 future
 threddsclient
 pavics

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+setuptools
+pywps
+requests
+pavics

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ here = os.path.abspath(os.path.dirname(__file__))
 README = open(os.path.join(here, 'README.md')).read()
 CHANGES = open(os.path.join(here, 'CHANGES.md')).read()
 
-reqs = ['pywps', 'pavics']
+REQUIREMENTS = set([])  # use set to have unique packages by name
+with open('requirements.txt', 'r') as requirements_file:
+    [REQUIREMENTS.add(line.strip()) for line in requirements_file]
+REQUIREMENTS = list(REQUIREMENTS)
 
 classifiers = [
     'Development Status :: 4 - Beta',
@@ -19,11 +22,13 @@ classifiers = [
     'Programming Language :: Python',
     'Topic :: Scientific/Engineering :: Atmospheric Science']
 
+
 def my_test_suite():
     test_loader = unittest.TestLoader()
     test_suite = test_loader.discover('pavics_datacatalog/tests',
                                       pattern='test_*.py')
     return test_suite
+
 
 setup(name='pavics_datacatalog',
       version='0.6.5',
@@ -41,6 +46,6 @@ setup(name='pavics_datacatalog',
       include_package_data=True,
       zip_safe=False,
       test_suite='setup.my_test_suite',
-      install_requires=reqs,
+      install_requires=REQUIREMENTS,
       entry_points={'console_scripts': []},
       )


### PR DESCRIPTION
Just another way to install stuff quickly.
Having a `requirements.txt` allows PyCharm to setup everything automatically, or flag easily missing packages.
